### PR TITLE
Add GitHub OAuth flow to MCP worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Use this guide to contribute confidently to the Cloudflare-based MCP server host
 
 ## Project Structure & Module Organization
 - `src/index.ts`: entry point that registers MCP tools through the SDK.
+- `src/github-handler.ts`, `src/utils.ts`, `src/workers-oauth-utils.ts`: GitHub OAuth handshake routes, helpers, and approval UI.
 - `wrangler.jsonc` and `worker-configuration.d.ts`: Worker runtime config and generated types.
 - `biome.json`, `tsconfig.json`, and `package.json`: shared tooling settings; keep updates minimal and well documented.
 Place new source modules under `src/` and co-locate helper utilities or schemas near their consumers for quicker discovery.
@@ -25,4 +26,4 @@ There is no dedicated test runner yet; rely on `npm run type-check`, targeted un
 Write concise, imperative commit messages (e.g., "Add calculator tool binding"). For PRs, describe the change, list verification steps (commands run, manual checks), link related issues, and attach screenshots or logs if behavior is user-visible. Ensure CI passes locally before requesting review.
 
 ## Security & Configuration Tips
-Do not commit secrets or account identifiers. Use `wrangler secret put <NAME>` to inject credentials at deploy time, and prefer environment variables for local testing. Review Cloudflare access levels before deploying new tools to avoid exposing privileged operations.
+Do not commit secrets or account identifiers. Store `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `COOKIE_ENCRYPTION_KEY` via `wrangler secret put` and mirror them in `.dev.vars` for local work. Review Cloudflare access levels before deploying new tools to avoid exposing privileged operations, and update the `OAUTH_KV` binding IDs in `wrangler.jsonc` whenever you recreate the namespace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Repository Guidelines
+
+Use this guide to contribute confidently to the Cloudflare-based MCP server hosted in this repo.
+
+## Project Structure & Module Organization
+- `src/index.ts`: entry point that registers MCP tools through the SDK.
+- `wrangler.jsonc` and `worker-configuration.d.ts`: Worker runtime config and generated types.
+- `biome.json`, `tsconfig.json`, and `package.json`: shared tooling settings; keep updates minimal and well documented.
+Place new source modules under `src/` and co-locate helper utilities or schemas near their consumers for quicker discovery.
+
+## Build, Test, and Development Commands
+- `npm run dev` (alias `npm start`): runs `wrangler dev` for a local Worker with live reload.
+- `npm run deploy`: publishes the Worker via Wrangler using the active Cloudflare account.
+- `npm run cf-typegen`: refreshes Cloudflare bindings and types after config changes.
+- `npm run type-check`: verifies TypeScript without emitting JavaScript.
+- `npm run format` / `npm run lint:fix`: applies Biome formatting and autofixes lint issues; run before submitting changes.
+
+## Coding Style & Naming Conventions
+TypeScript is required. Biome enforces 4-space indentation and a 100-character line width—do not override locally. Prefer `camelCase` for variables/functions, `PascalCase` for classes, Zod schemas, and exported tool names, and keep file names kebab-case. Use Biome’s autofix commands instead of manual tweaks whenever possible.
+
+## Testing Guidelines
+There is no dedicated test runner yet; rely on `npm run type-check`, targeted unit tests you add under `src/__tests__`, and manual validation through `npm run dev`. Name test files `<module>.test.ts` and prefer Zod validations or SDK mocks to cover tool behavior. Document any manual test steps in your PR description so others can reproduce them.
+
+## Commit & Pull Request Guidelines
+Write concise, imperative commit messages (e.g., "Add calculator tool binding"). For PRs, describe the change, list verification steps (commands run, manual checks), link related issues, and attach screenshots or logs if behavior is user-visible. Ensure CI passes locally before requesting review.
+
+## Security & Configuration Tips
+Do not commit secrets or account identifiers. Use `wrangler secret put <NAME>` to inject credentials at deploy time, and prefer environment variables for local testing. Review Cloudflare access levels before deploying new tools to avoid exposing privileged operations.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,66 @@
-# Building a Remote MCP Server on Cloudflare (Without Auth)
+### Project Overview
 
-This example allows you to deploy a remote MCP server that doesn't require authentication on Cloudflare Workers. 
+This project is a Cloudflare Worker that implements a remote MCP (Model Context Protocol) server. It's designed to be deployed on Cloudflare's serverless platform and provides a set of tools that can be accessed by an MCP client, such as the Cloudflare AI Playground or Claude Desktop. The server is "authless," meaning it doesn't require any authentication to use its tools.
 
-## Get started: 
+The core logic is in `src/index.ts`, which defines an `McpAgent` with a tool for interacting with GitHub. The server uses Cloudflare Durable Objects to maintain the state of the MCP agent.
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless)
+The project is written in TypeScript and uses `wrangler` for development and deployment. It also includes configuration for `biome` for linting and formatting, and `tsc` for type-checking.
 
-This will deploy your MCP server to a URL like: `remote-mcp-server-authless.<your-account>.workers.dev/sse`
+### Available Tools
 
-Alternatively, you can use the command line below to get the remote MCP Server created on your local machine:
+#### `list_user_repos`
+
+*   **Function**: Lists the public repositories for a given GitHub user.
+*   **Parameters**:
+    *   `username` (string): The GitHub username to fetch repositories for.
+*   **Example Usage**: `list_user_repos(username: "google")`
+
+### Building and Running
+
+**Dependencies:**
+
+*   Node.js and npm
+*   Wrangler CLI
+
+**Installation:**
+
 ```bash
-npm create cloudflare@latest -- my-mcp-server --template=cloudflare/ai/demos/remote-mcp-authless
+npm install
 ```
 
-## Customizing your MCP Server
+**Running in Development:**
 
-To add your own [tools](https://developers.cloudflare.com/agents/model-context-protocol/tools/) to the MCP server, define each tool inside the `init()` method of `src/index.ts` using `this.server.tool(...)`. 
+To run the worker locally, you need to create a `.dev.vars` file in the root of the project and add your GitHub personal access token:
 
-## Connect to Cloudflare AI Playground
-
-You can connect to your MCP server from the Cloudflare AI Playground, which is a remote MCP client:
-
-1. Go to https://playground.ai.cloudflare.com/
-2. Enter your deployed MCP server URL (`remote-mcp-server-authless.<your-account>.workers.dev/sse`)
-3. You can now use your MCP tools directly from the playground!
-
-## Connect Claude Desktop to your MCP server
-
-You can also connect to your remote MCP server from local MCP clients, by using the [mcp-remote proxy](https://www.npmjs.com/package/mcp-remote). 
-
-To connect to your MCP server from Claude Desktop, follow [Anthropic's Quickstart](https://modelcontextprotocol.io/quickstart/user) and within Claude Desktop go to Settings > Developer > Edit Config.
-
-Update with this configuration:
-
-```json
-{
-  "mcpServers": {
-    "calculator": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "http://localhost:8787/sse"  // or remote-mcp-server-authless.your-account.workers.dev/sse
-      ]
-    }
-  }
-}
+```
+GITHUB_TOKEN="your_github_token_here"
 ```
 
-Restart Claude and you should see the tools become available. 
+Then, run the following command:
+
+```bash
+npm run dev
+```
+
+This will start a local development server at `http://localhost:8787`.
+
+**Deploying to Cloudflare:**
+
+Before deploying, you need to set the `GITHUB_TOKEN` as a secret in your Cloudflare Worker's settings.
+
+1.  Go to your Worker in the Cloudflare dashboard.
+2.  Navigate to **Settings** > **Variables**.
+3.  Under **Environment Variables**, add a secret variable named `GITHUB_TOKEN` with your GitHub token as the value.
+
+After setting the secret, deploy the worker:
+
+```bash
+npm run deploy
+```
+
+### Development Conventions
+
+*   **Code Style:** The project uses Biome for code formatting and linting. The configuration is in `biome.json`.
+*   **Typing:** The project uses TypeScript with strict mode enabled. The configuration is in `tsconfig.json`.
+*   **API Interaction**: The project uses the native `fetch` API to interact with the GitHub API. No external libraries like `@octokit/rest` are required.
+*   **Authentication**: A GitHub personal access token is required for API authentication. This is managed through the `GITHUB_TOKEN` environment variable.

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
 		"type-check": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@cloudflare/workers-oauth-provider": "^0.0.11",
 		"@modelcontextprotocol/sdk": "1.19.1",
 		"agents": "^0.2.8",
+		"hono": "^4.9.9",
+		"octokit": "^5.0.3",
 		"zod": "^3.25.76"
 	},
 	"devDependencies": {

--- a/src/github-handler.ts
+++ b/src/github-handler.ts
@@ -1,0 +1,103 @@
+import { env } from "cloudflare:workers";
+import type { AuthRequest, OAuthHelpers } from "@cloudflare/workers-oauth-provider";
+import { Hono } from "hono";
+import { Octokit } from "octokit";
+import { fetchUpstreamAuthToken, getUpstreamAuthorizeUrl, type Props } from "./utils";
+import {
+	clientIdAlreadyApproved,
+	parseRedirectApproval,
+	renderApprovalDialog,
+} from "./workers-oauth-utils";
+
+const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
+
+app.get("/authorize", async (c) => {
+	const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+	const { clientId } = oauthReqInfo;
+	if (!clientId) {
+		return c.text("Invalid request", 400);
+	}
+
+	if (
+		await clientIdAlreadyApproved(c.req.raw, oauthReqInfo.clientId, env.COOKIE_ENCRYPTION_KEY)
+	) {
+		return redirectToGithub(c.req.raw, oauthReqInfo);
+	}
+
+	return renderApprovalDialog(c.req.raw, {
+		client: await c.env.OAUTH_PROVIDER.lookupClient(clientId),
+		server: {
+			description: "Authenticate with GitHub to unlock the personal MCP tools hosted on Cloudflare.",
+			logo: "https://avatars.githubusercontent.com/u/9919?v=4",
+			name: "Personal MCP GitHub Server",
+		},
+		state: { oauthReqInfo },
+	});
+});
+
+app.post("/authorize", async (c) => {
+	const { state, headers } = await parseRedirectApproval(c.req.raw, env.COOKIE_ENCRYPTION_KEY);
+	if (!state.oauthReqInfo) {
+		return c.text("Invalid request", 400);
+	}
+
+	return redirectToGithub(c.req.raw, state.oauthReqInfo, headers);
+});
+
+async function redirectToGithub(
+	request: Request,
+	oauthReqInfo: AuthRequest,
+	headers: Record<string, string> = {},
+) {
+	return new Response(null, {
+		headers: {
+			...headers,
+			location: getUpstreamAuthorizeUrl({
+				client_id: env.GITHUB_CLIENT_ID,
+				redirect_uri: new URL("/callback", request.url).href,
+				scope: "read:user",
+				state: btoa(JSON.stringify(oauthReqInfo)),
+				upstream_url: "https://github.com/login/oauth/authorize",
+			}),
+		},
+		status: 302,
+	});
+}
+
+app.get("/callback", async (c) => {
+	const oauthReqInfo = JSON.parse(atob(c.req.query("state") as string)) as AuthRequest;
+	if (!oauthReqInfo.clientId) {
+		return c.text("Invalid state", 400);
+	}
+
+	const [accessToken, errResponse] = await fetchUpstreamAuthToken({
+		client_id: c.env.GITHUB_CLIENT_ID,
+		client_secret: c.env.GITHUB_CLIENT_SECRET,
+		code: c.req.query("code"),
+		redirect_uri: new URL("/callback", c.req.url).href,
+		upstream_url: "https://github.com/login/oauth/access_token",
+	});
+	if (errResponse) return errResponse;
+
+	const user = await new Octokit({ auth: accessToken }).rest.users.getAuthenticated();
+	const { login, name, email } = user.data;
+
+	const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
+		metadata: {
+			label: name ?? login,
+		},
+		props: {
+			accessToken,
+			email: email ?? "",
+			login,
+			name: name ?? login,
+		} as Props,
+		request: oauthReqInfo,
+		scope: oauthReqInfo.scope,
+		userId: login,
+	});
+
+	return Response.redirect(redirectTo);
+});
+
+export { app as GitHubHandler };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,72 @@
+/**
+ * Constructs an authorization URL for an upstream service.
+ */
+export function getUpstreamAuthorizeUrl({
+	upstream_url,
+	client_id,
+	scope,
+	redirect_uri,
+	state,
+}: {
+	upstream_url: string;
+	client_id: string;
+	scope: string;
+	redirect_uri: string;
+	state?: string;
+}) {
+	const upstream = new URL(upstream_url);
+	upstream.searchParams.set("client_id", client_id);
+	upstream.searchParams.set("redirect_uri", redirect_uri);
+	upstream.searchParams.set("scope", scope);
+	if (state) upstream.searchParams.set("state", state);
+	upstream.searchParams.set("response_type", "code");
+	return upstream.href;
+}
+
+/**
+ * Exchanges the authorization code for an access token against the upstream.
+ */
+export async function fetchUpstreamAuthToken({
+	client_id,
+	client_secret,
+	code,
+	redirect_uri,
+	upstream_url,
+}: {
+	code: string | undefined;
+	upstream_url: string;
+	client_secret: string;
+	redirect_uri: string;
+	client_id: string;
+}): Promise<[string, null] | [null, Response]> {
+	if (!code) {
+		return [null, new Response("Missing code", { status: 400 })];
+	}
+
+	const resp = await fetch(upstream_url, {
+		body: new URLSearchParams({ client_id, client_secret, code, redirect_uri }).toString(),
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		method: "POST",
+	});
+	if (!resp.ok) {
+		console.log(await resp.text());
+		return [null, new Response("Failed to fetch access token", { status: 500 })];
+	}
+	const body = await resp.formData();
+	const accessToken = body.get("access_token") as string;
+	if (!accessToken) {
+		return [null, new Response("Missing access token", { status: 400 })];
+	}
+	return [accessToken, null];
+}
+
+// Context from the auth process, encrypted & stored in the auth token
+// and provided to the DurableMCP as this.props
+export type Props = {
+	login: string;
+	name: string;
+	email: string;
+	accessToken: string;
+};

--- a/src/workers-oauth-utils.ts
+++ b/src/workers-oauth-utils.ts
@@ -1,0 +1,524 @@
+// workers-oauth-utils.ts
+
+import type { AuthRequest, ClientInfo } from "@cloudflare/workers-oauth-provider";
+
+const COOKIE_NAME = "mcp-approved-clients";
+const ONE_YEAR_IN_SECONDS = 31536000;
+
+function _encodeState(data: any): string {
+	try {
+		const jsonString = JSON.stringify(data);
+		return btoa(jsonString);
+	} catch (e) {
+		console.error("Error encoding state:", e);
+		throw new Error("Could not encode state");
+	}
+}
+
+function decodeState<T = any>(encoded: string): T {
+	try {
+		const jsonString = atob(encoded);
+		return JSON.parse(jsonString);
+	} catch (e) {
+		console.error("Error decoding state:", e);
+		throw new Error("Could not decode state");
+	}
+}
+
+async function importKey(secret: string): Promise<CryptoKey> {
+	if (!secret) {
+		throw new Error(
+			"COOKIE_SECRET is not defined. A secret key is required for signing cookies.",
+		);
+	}
+	const enc = new TextEncoder();
+	return crypto.subtle.importKey(
+		"raw",
+		enc.encode(secret),
+		{ hash: "SHA-256", name: "HMAC" },
+		false,
+		["sign", "verify"],
+	);
+}
+
+async function signData(key: CryptoKey, data: string): Promise<string> {
+	const enc = new TextEncoder();
+	const signatureBuffer = await crypto.subtle.sign("HMAC", key, enc.encode(data));
+	return Array.from(new Uint8Array(signatureBuffer))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+async function verifySignature(
+	key: CryptoKey,
+	signatureHex: string,
+	data: string,
+): Promise<boolean> {
+	const enc = new TextEncoder();
+	try {
+		const signatureBytes = new Uint8Array(
+			signatureHex.match(/.{1,2}/g)!.map((byte) => Number.parseInt(byte, 16)),
+		);
+		return await crypto.subtle.verify("HMAC", key, signatureBytes.buffer, enc.encode(data));
+	} catch (e) {
+		console.error("Error verifying signature:", e);
+		return false;
+	}
+}
+
+async function getApprovedClientsFromCookie(
+	cookieHeader: string | null,
+	secret: string,
+): Promise<string[] | null> {
+	if (!cookieHeader) return null;
+
+	const cookies = cookieHeader.split(";").map((c) => c.trim());
+	const targetCookie = cookies.find((c) => c.startsWith(`${COOKIE_NAME}=`));
+
+	if (!targetCookie) return null;
+
+	const cookieValue = targetCookie.substring(COOKIE_NAME.length + 1);
+	const parts = cookieValue.split(".");
+
+	if (parts.length !== 2) {
+		console.warn("Invalid cookie format received.");
+		return null;
+	}
+
+	const [signatureHex, base64Payload] = parts;
+	const payload = atob(base64Payload);
+
+	const key = await importKey(secret);
+	const isValid = await verifySignature(key, signatureHex, payload);
+
+	if (!isValid) {
+		console.warn("Cookie signature verification failed.");
+		return null;
+	}
+
+	try {
+		const approvedClients = JSON.parse(payload);
+		if (!Array.isArray(approvedClients)) {
+			console.warn("Cookie payload is not an array.");
+			return null;
+		}
+		if (!approvedClients.every((item) => typeof item === "string")) {
+			console.warn("Cookie payload contains non-string elements.");
+			return null;
+		}
+		return approvedClients as string[];
+	} catch (e) {
+		console.error("Error parsing cookie payload:", e);
+		return null;
+	}
+}
+
+export async function clientIdAlreadyApproved(
+	request: Request,
+	clientId: string,
+	cookieSecret: string,
+): Promise<boolean> {
+	if (!clientId) return false;
+	const cookieHeader = request.headers.get("Cookie");
+	const approvedClients = await getApprovedClientsFromCookie(cookieHeader, cookieSecret);
+
+	return approvedClients?.includes(clientId) ?? false;
+}
+
+export interface ApprovalDialogOptions {
+	client: ClientInfo | null;
+	server: {
+		name: string;
+		logo?: string;
+		description?: string;
+	};
+	state: Record<string, any>;
+	cookieName?: string;
+	cookieSecret?: string | Uint8Array;
+	cookieDomain?: string;
+	cookiePath?: string;
+	cookieMaxAge?: number;
+}
+
+export function renderApprovalDialog(request: Request, options: ApprovalDialogOptions): Response {
+	const { client, server, state } = options;
+
+	const encodedState = btoa(JSON.stringify(state));
+
+	const serverName = sanitizeHtml(server.name);
+	const clientName = client?.clientName ? sanitizeHtml(client.clientName) : "Unknown MCP Client";
+	const serverDescription = server.description ? sanitizeHtml(server.description) : "";
+
+	const logoUrl = server.logo ? sanitizeHtml(server.logo) : "";
+	const clientUri = client?.clientUri ? sanitizeHtml(client.clientUri) : "";
+	const policyUri = client?.policyUri ? sanitizeHtml(client.policyUri) : "";
+	const tosUri = client?.tosUri ? sanitizeHtml(client.tosUri) : "";
+
+	const contacts =
+		client?.contacts && client.contacts.length > 0
+			? sanitizeHtml(client.contacts.join(", "))
+			: "";
+
+	const redirectUris =
+		client?.redirectUris && client.redirectUris.length > 0
+			? client.redirectUris.map((uri) => sanitizeHtml(uri))
+			: [];
+
+	const htmlContent = `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>${clientName} | Authorization Request</title>
+        <style>
+          :root {
+            --primary-color: #0070f3;
+            --error-color: #f44336;
+            --border-color: #e5e7eb;
+            --text-color: #333;
+            --background-color: #fff;
+            --card-shadow: 0 8px 36px 8px rgba(0, 0, 0, 0.1);
+          }
+          
+          body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, 
+                         Helvetica, Arial, sans-serif, "Apple Color Emoji", 
+                         "Segoe UI Emoji", "Segoe UI Symbol";
+            line-height: 1.6;
+            color: var(--text-color);
+            background-color: #f9fafb;
+            margin: 0;
+            padding: 0;
+          }
+          
+          .container {
+            max-width: 600px;
+            margin: 2rem auto;
+            padding: 1rem;
+          }
+          
+          .precard {
+            padding: 2rem;
+            text-align: center;
+          }
+          
+          .card {
+            background-color: var(--background-color);
+            border-radius: 8px;
+            box-shadow: var(--card-shadow);
+            padding: 2rem;
+          }
+          
+          .header {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 1.5rem;
+          }
+          
+          .logo {
+            width: 48px;
+            height: 48px;
+            margin-right: 1rem;
+            border-radius: 8px;
+            object-fit: contain;
+          }
+          
+          .title {
+            margin: 0;
+            font-size: 1.3rem;
+            font-weight: 400;
+          }
+          
+          .alert {
+            margin: 0;
+            font-size: 1.5rem;
+            font-weight: 400;
+            margin: 1rem 0;
+            text-align: center;
+          }
+          
+          .description {
+            color: #555;
+          }
+          
+          .client-info {
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            padding: 1rem 1rem 0.5rem;
+            margin-bottom: 1.5rem;
+          }
+          
+          .client-name {
+            font-weight: 600;
+            font-size: 1.2rem;
+            margin: 0 0 0.5rem 0;
+          }
+          
+          .client-detail {
+            display: flex;
+            margin-bottom: 0.5rem;
+            align-items: baseline;
+          }
+          
+          .detail-label {
+            font-weight: 500;
+            min-width: 120px;
+          }
+          
+          .detail-value {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            word-break: break-all;
+          }
+          
+          .detail-value a {
+            color: inherit;
+            text-decoration: underline;
+          }
+          
+          .detail-value.small {
+            font-size: 0.8em;
+          }
+          
+          .external-link-icon {
+            font-size: 0.75em;
+            margin-left: 0.25rem;
+            vertical-align: super;
+          }
+          
+          .actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 1rem;
+            margin-top: 2rem;
+          }
+          
+          .button {
+            padding: 0.75rem 1.5rem;
+            border-radius: 6px;
+            font-weight: 500;
+            cursor: pointer;
+            border: none;
+            font-size: 1rem;
+          }
+          
+          .button-primary {
+            background-color: var(--primary-color);
+            color: white;
+          }
+          
+          .button-secondary {
+            background-color: transparent;
+            border: 1px solid var(--border-color);
+            color: var(--text-color);
+          }
+          
+          @media (max-width: 640px) {
+            .container {
+              margin: 1rem auto;
+              padding: 0.5rem;
+            }
+            
+            .card {
+              padding: 1.5rem;
+            }
+            
+            .client-detail {
+              flex-direction: column;
+            }
+            
+            .detail-label {
+              min-width: unset;
+              margin-bottom: 0.25rem;
+            }
+            
+            .actions {
+              flex-direction: column;
+            }
+            
+            .button {
+              width: 100%;
+            }
+          }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="precard">
+            <div class="header">
+              ${logoUrl ? `<img src="${logoUrl}" alt="${serverName} Logo" class="logo">` : ""}
+            <h1 class="title"><strong>${serverName}</strong></h1>
+            </div>
+            
+            ${serverDescription ? `<p class="description">${serverDescription}</p>` : ""}
+          </div>
+            
+          <div class="card">
+            
+            <h2 class="alert"><strong>${clientName || "A new MCP Client"}</strong> is requesting access</h2>
+            
+            <div class="client-info">
+              <div class="client-detail">
+                <div class="detail-label">Name:</div>
+                <div class="detail-value">
+                  ${clientName}
+                </div>
+              </div>
+              
+              ${
+					clientUri
+						? `
+                <div class="client-detail">
+                  <div class="detail-label">Website:</div>
+                  <div class="detail-value small">
+                    <a href="${clientUri}" target="_blank" rel="noopener noreferrer">
+                      ${clientUri}
+                    </a>
+                  </div>
+                </div>
+              `
+						: ""
+				}
+              
+              ${
+					policyUri
+						? `
+                <div class="client-detail">
+                  <div class="detail-label">Privacy Policy:</div>
+                  <div class="detail-value">
+                    <a href="${policyUri}" target="_blank" rel="noopener noreferrer">
+                      ${policyUri}
+                    </a>
+                  </div>
+                </div>
+              `
+						: ""
+				}
+              
+              ${
+					tosUri
+						? `
+                <div class="client-detail">
+                  <div class="detail-label">Terms of Service:</div>
+                  <div class="detail-value">
+                    <a href="${tosUri}" target="_blank" rel="noopener noreferrer">
+                      ${tosUri}
+                    </a>
+                  </div>
+                </div>
+              `
+						: ""
+				}
+              
+              ${
+					redirectUris.length > 0
+						? `
+                <div class="client-detail">
+                  <div class="detail-label">Redirect URIs:</div>
+                  <div class="detail-value small">
+                    ${redirectUris.map((uri) => `<div>${uri}</div>`).join("")}
+                  </div>
+                </div>
+              `
+						: ""
+				}
+              
+              ${
+					contacts
+						? `
+                <div class="client-detail">
+                  <div class="detail-label">Contact:</div>
+                  <div class="detail-value">${contacts}</div>
+                </div>
+              `
+						: ""
+				}
+            </div>
+            
+            <p>This MCP Client is requesting to be authorized on ${serverName}. If you approve, you will be redirected to complete authentication.</p>
+            
+            <form method="post" action="${new URL(request.url).pathname}">
+              <input type="hidden" name="state" value="${encodedState}">
+              
+              <div class="actions">
+                <button type="button" class="button button-secondary" onclick="window.history.back()">Cancel</button>
+                <button type="submit" class="button button-primary">Approve</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </body>
+    </html>
+  `;
+
+	return new Response(htmlContent, {
+		headers: {
+			"Content-Type": "text/html; charset=utf-8",
+		},
+	});
+}
+
+export interface ParsedApprovalResult {
+	state: any;
+	headers: Record<string, string>;
+}
+
+export async function parseRedirectApproval(
+	request: Request,
+	cookieSecret: string,
+): Promise<ParsedApprovalResult> {
+	if (request.method !== "POST") {
+		throw new Error("Invalid request method. Expected POST.");
+	}
+
+	let state: any;
+	let clientId: string | undefined;
+
+	try {
+		const formData = await request.formData();
+		const encodedState = formData.get("state");
+
+		if (typeof encodedState !== "string" || !encodedState) {
+			throw new Error("Missing or invalid 'state' in form data.");
+		}
+
+		state = decodeState<{ oauthReqInfo?: AuthRequest }>(encodedState);
+		clientId = state?.oauthReqInfo?.clientId;
+
+		if (!clientId) {
+			throw new Error("Could not extract clientId from state object.");
+		}
+	} catch (e) {
+		console.error("Error processing form submission:", e);
+		throw new Error(
+			`Failed to parse approval form: ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
+
+	const cookieHeader = request.headers.get("Cookie");
+	const existingApprovedClients =
+		(await getApprovedClientsFromCookie(cookieHeader, cookieSecret)) || [];
+
+	const updatedApprovedClients = Array.from(new Set([...existingApprovedClients, clientId]));
+
+	const payload = JSON.stringify(updatedApprovedClients);
+	const key = await importKey(cookieSecret);
+	const signature = await signData(key, payload);
+	const newCookieValue = `${signature}.${btoa(payload)}`;
+
+	const headers: Record<string, string> = {
+		"Set-Cookie": `${COOKIE_NAME}=${newCookieValue}; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=${ONE_YEAR_IN_SECONDS}`,
+	};
+
+	return { headers, state };
+}
+
+function sanitizeHtml(unsafe: string): string {
+	return unsafe
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -5,7 +5,10 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		MCP_OBJECT: DurableObjectNamespace<import("./src/index").MyMCP>;
 		ASSETS: Fetcher;
-		GITHUB_TOKEN: string;
+		GITHUB_CLIENT_ID: string;
+		GITHUB_CLIENT_SECRET: string;
+		COOKIE_ENCRYPTION_KEY: string;
+		OAUTH_PROVIDER: import("@cloudflare/workers-oauth-provider").OAuthHelpers;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -5,6 +5,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		MCP_OBJECT: DurableObjectNamespace<import("./src/index").MyMCP>;
 		ASSETS: Fetcher;
+		GITHUB_TOKEN: string;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,15 @@
 	"main": "src/index.ts",
 	"compatibility_date": "2025-03-10",
 	"compatibility_flags": ["nodejs_compat"],
+	"dev": {
+		"port": 8788
+	},
+	/**
+	 * Secrets you must configure before deploying:
+	 * wrangler secret put GITHUB_CLIENT_ID
+	 * wrangler secret put GITHUB_CLIENT_SECRET
+	 * wrangler secret put COOKIE_ENCRYPTION_KEY
+	 */
 	"migrations": [
 		{
 			"new_sqlite_classes": ["MyMCP"],
@@ -22,6 +31,13 @@
 			}
 		]
 	},
+	"kv_namespaces": [
+		{
+			"binding": "OAUTH_KV",
+			"id": "<replace-with-production-kv-id>",
+			"preview_id": "<replace-with-preview-kv-id>"
+		}
+	],
 	"observability": {
 		"enabled": true
 	}


### PR DESCRIPTION
## Summary
- replace the authless worker with a GitHub OAuth-protected MCP server
- add OAuth handler routes, approval dialog utilities, and Octokit-based tools
- document required secrets, KV bindings, and contributor guidelines for OAuth setup

## Testing
- npm install (fails: requires Node >= 20 for octokit dependencies)