### PR TITLE
Fix npm ci by syncing lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
-	"name": "remote-mcp-server-authless",
+	"name": "personal-authless",
 	"version": "0.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "remote-mcp-server-authless",
+			"name": "personal-authless",
 			"version": "0.0.0",
 			"dependencies": {
+				"@cloudflare/workers-oauth-provider": "^0.0.11",
 				"@modelcontextprotocol/sdk": "1.19.1",
 				"agents": "^0.2.8",
+				"hono": "^4.9.9",
+				"octokit": "^5.0.3",
 				"zod": "^3.25.76"
 			},
 			"devDependencies": {
@@ -377,6 +380,11 @@
 			"engines": {
 				"node": ">=16"
 			}
+		},
+		"node_modules/@cloudflare/workers-oauth-provider": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.0.11.tgz",
+			"integrity": "sha512-uarVcE1y/lf0y6iMFTwpJe8u6kpDP9CRZQTsGfCFonCEmH9n9b8k4ZmFpxI5g4XfoS7s9YHO0XcSRH8fgsjHWA=="
 		},
 		"node_modules/@cloudflare/workers-types": {
 			"version": "4.20251003.0",
@@ -1271,6 +1279,530 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@octokit/app": {
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.1.tgz",
+			"integrity": "sha512-pcvKSN6Q6aT3gU5heoDFs3ywU5xejxeqs1rQpUwgN7CmBlxCSy9aCoqFuC6GpVv71O/Qq/VuYfCNzrOZp/9Ycw==",
+			"dependencies": {
+				"@octokit/auth-app": "^8.1.1",
+				"@octokit/auth-unauthenticated": "^7.0.2",
+				"@octokit/core": "^7.0.5",
+				"@octokit/oauth-app": "^8.0.2",
+				"@octokit/plugin-paginate-rest": "^13.2.0",
+				"@octokit/types": "^15.0.0",
+				"@octokit/webhooks": "^14.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/app/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/app/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-app": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.1.1.tgz",
+			"integrity": "sha512-yW9YUy1cuqWlz8u7908ed498wJFt42VYsYWjvepjojM4BdZSp4t+5JehFds7LfvYi550O/GaUI94rgbhswvxfA==",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^9.0.2",
+				"@octokit/auth-oauth-user": "^6.0.1",
+				"@octokit/request": "^10.0.5",
+				"@octokit/request-error": "^7.0.1",
+				"@octokit/types": "^15.0.0",
+				"toad-cache": "^3.7.0",
+				"universal-github-app-jwt": "^2.2.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.2.tgz",
+			"integrity": "sha512-vmjSHeuHuM+OxZLzOuoYkcY3OPZ8erJ5lfswdTmm+4XiAKB5PmCk70bA1is4uwSl/APhRVAv4KHsgevWfEKIPQ==",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^8.0.2",
+				"@octokit/auth-oauth-user": "^6.0.1",
+				"@octokit/request": "^10.0.5",
+				"@octokit/types": "^15.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.2.tgz",
+			"integrity": "sha512-KW7Ywrz7ei7JX+uClWD2DN1259fnkoKuVdhzfpQ3/GdETaCj4Tx0IjvuJrwhP/04OhcMu5yR6tjni0V6LBihdw==",
+			"dependencies": {
+				"@octokit/oauth-methods": "^6.0.1",
+				"@octokit/request": "^10.0.5",
+				"@octokit/types": "^15.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.1.tgz",
+			"integrity": "sha512-vlKsL1KUUPvwXpv574zvmRd+/4JiDFXABIZNM39+S+5j2kODzGgjk7w5WtiQ1x24kRKNaE7v9DShNbw43UA3Hw==",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^8.0.2",
+				"@octokit/oauth-methods": "^6.0.1",
+				"@octokit/request": "^10.0.5",
+				"@octokit/types": "^15.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-unauthenticated": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.2.tgz",
+			"integrity": "sha512-vjcPRP1xsKWdYKiyKmHkLFCxeH4QvVTv05VJlZxwNToslBFcHRJlsWRaoI2+2JGCf9tIM99x8cN0b1rlAHJiQw==",
+			"dependencies": {
+				"@octokit/request-error": "^7.0.1",
+				"@octokit/types": "^15.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.5.tgz",
+			"integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
+			"dependencies": {
+				"@octokit/auth-token": "^6.0.0",
+				"@octokit/graphql": "^9.0.2",
+				"@octokit/request": "^10.0.4",
+				"@octokit/request-error": "^7.0.1",
+				"@octokit/types": "^15.0.0",
+				"before-after-hook": "^4.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.1.tgz",
+			"integrity": "sha512-7P1dRAZxuWAOPI7kXfio88trNi/MegQ0IJD3vfgC3b+LZo1Qe6gRJc2v0mz2USWWJOKrB2h5spXCzGbw+fAdqA==",
+			"dependencies": {
+				"@octokit/types": "^15.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.2.tgz",
+			"integrity": "sha512-iz6KzZ7u95Fzy9Nt2L8cG88lGRMr/qy1Q36ih/XVzMIlPDMYwaNLE/ENhqmIzgPrlNWiYJkwmveEetvxAgFBJw==",
+			"dependencies": {
+				"@octokit/request": "^10.0.4",
+				"@octokit/types": "^15.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/oauth-app": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.2.tgz",
+			"integrity": "sha512-Oln8yKrDIDKnp49GUCSqda+XZyocmNapumjA0JdTpRfwMpmFMnh3bCOtSgb3X/kHfdtT7Q9ihFeN1djn58forg==",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^9.0.2",
+				"@octokit/auth-oauth-user": "^6.0.1",
+				"@octokit/auth-unauthenticated": "^7.0.2",
+				"@octokit/core": "^7.0.5",
+				"@octokit/oauth-authorization-url": "^8.0.0",
+				"@octokit/oauth-methods": "^6.0.1",
+				"@types/aws-lambda": "^8.10.83",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/oauth-authorization-url": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+			"integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/oauth-methods": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.1.tgz",
+			"integrity": "sha512-xi6Iut3izMCFzXBJtxxJehxJmAKjE8iwj6L5+raPRwlTNKAbOOBJX7/Z8AF5apD4aXvc2skwIdOnC+CQ4QuA8Q==",
+			"dependencies": {
+				"@octokit/oauth-authorization-url": "^8.0.0",
+				"@octokit/request": "^10.0.5",
+				"@octokit/request-error": "^7.0.1",
+				"@octokit/types": "^15.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "25.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+			"integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
+		},
+		"node_modules/@octokit/openapi-webhooks-types": {
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.0.3.tgz",
+			"integrity": "sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA=="
+		},
+		"node_modules/@octokit/plugin-paginate-graphql": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
+			"integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.2.0.tgz",
+			"integrity": "sha512-YuAlyjR8o5QoRSOvMHxSJzPtogkNMgeMv2mpccrvdUGeC3MKyfi/hS+KiFwyH/iRKIKyx+eIMsDjbt3p9r2GYA==",
+			"dependencies": {
+				"@octokit/types": "^15.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.1.0.tgz",
+			"integrity": "sha512-nCsyiKoGRnhH5LkH8hJEZb9swpqOcsW+VXv1QoyUNQXJeVODG4+xM6UICEqyqe9XFr6LkL8BIiFCPev8zMDXPw==",
+			"dependencies": {
+				"@octokit/types": "^15.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.2.tgz",
+			"integrity": "sha512-mVPCe77iaD8g1lIX46n9bHPUirFLzc3BfIzsZOpB7bcQh1ecS63YsAgcsyMGqvGa2ARQWKEFTrhMJX2MLJVHVw==",
+			"dependencies": {
+				"@octokit/request-error": "^7.0.1",
+				"@octokit/types": "^15.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=7"
+			}
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.2.tgz",
+			"integrity": "sha512-ntNIig4zZhQVOZF4fG9Wt8QCoz9ehb+xnlUwp74Ic2ANChCk8oKmRwV9zDDCtrvU1aERIOvtng8wsalEX7Jk5Q==",
+			"dependencies": {
+				"@octokit/types": "^15.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^7.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "10.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.5.tgz",
+			"integrity": "sha512-TXnouHIYLtgDhKo+N6mXATnDBkV05VwbR0TtMWpgTHIoQdRQfCSzmy/LGqR1AbRMbijq/EckC/E3/ZNcU92NaQ==",
+			"dependencies": {
+				"@octokit/endpoint": "^11.0.1",
+				"@octokit/request-error": "^7.0.1",
+				"@octokit/types": "^15.0.0",
+				"fast-content-type-parse": "^3.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.1.tgz",
+			"integrity": "sha512-CZpFwV4+1uBrxu7Cw8E5NCXDWFNf18MSY23TdxCBgjw1tXXHvTrZVsXlW8hgFTOLw8RQR1BBrMvYRtuyaijHMA==",
+			"dependencies": {
+				"@octokit/types": "^15.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+			"integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@octokit/webhooks": {
+			"version": "14.1.3",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.1.3.tgz",
+			"integrity": "sha512-gcK4FNaROM9NjA0mvyfXl0KPusk7a1BeA8ITlYEZVQCXF5gcETTd4yhAU0Kjzd8mXwYHppzJBWgdBVpIR9wUcQ==",
+			"dependencies": {
+				"@octokit/openapi-webhooks-types": "12.0.3",
+				"@octokit/request-error": "^7.0.0",
+				"@octokit/webhooks-methods": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/webhooks-methods": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+			"integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1334,6 +1866,11 @@
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
 			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
 			"license": "MIT"
+		},
+		"node_modules/@types/aws-lambda": {
+			"version": "8.10.155",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.155.tgz",
+			"integrity": "sha512-wd1XgoL0gy/ybo7WozUKQBd+IOgUkdfG6uUGI0fQOTEq06FBFdO7tmPDSxgjkFkl8GlfApvk5TvqZlAl0g+Lbg=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -1450,6 +1987,11 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"license": "Python-2.0"
 		},
+		"node_modules/before-after-hook": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="
+		},
 		"node_modules/blake3-wasm": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -1476,6 +2018,11 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
@@ -1918,6 +2465,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-content-type-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+			"integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			]
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2084,6 +2646,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.9.10",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.9.10.tgz",
+			"integrity": "sha512-AlI15ijFyKTXR7eHo7QK7OR4RoKIedZvBuRjO8iy4zrxvlY5oFCdiRG/V/lFJHCNXJ0k72ATgnyzx8Yqa5arug==",
+			"engines": {
+				"node": ">=16.9.0"
 			}
 		},
 		"node_modules/http-errors": {
@@ -2446,6 +3016,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/octokit": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.3.tgz",
+			"integrity": "sha512-+bwYsAIRmYv30NTmBysPIlgH23ekVDriB07oRxlPIAH5PI0yTMSxg5i5Xy0OetcnZw+nk/caD4szD7a9YZ3QyQ==",
+			"dependencies": {
+				"@octokit/app": "^16.0.1",
+				"@octokit/core": "^7.0.2",
+				"@octokit/oauth-app": "^8.0.1",
+				"@octokit/plugin-paginate-graphql": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^13.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^16.0.0",
+				"@octokit/plugin-retry": "^8.0.1",
+				"@octokit/plugin-throttling": "^11.0.1",
+				"@octokit/request-error": "^7.0.0",
+				"@octokit/types": "^14.0.0",
+				"@octokit/webhooks": "^14.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/ohash": {
@@ -2945,6 +3536,14 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/toad-cache": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+			"integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3019,6 +3618,16 @@
 				"pathe": "^2.0.3",
 				"ufo": "^1.6.1"
 			}
+		},
+		"node_modules/universal-github-app-jwt": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+			"integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
+		},
+		"node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",


### PR DESCRIPTION
## Summary
- regenerate package-lock.json with npm@9 on Node 18 to include the new OAuth dependencies
- unblock npm ci by keeping package.json and lockfile in sync after the OAuth feature merge

## Testing
- npm install